### PR TITLE
Correct the link to the installation directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is home to the code that accompanies [Jon Krohn](https://www.jon
 
 ## Installation
 
-Step-by-step guides for running the code in this repository can be found in the [installation directory](https://github.com/the-deep-learners/TensorFlow-LiveLessons/tree/master/installation). 
+Step-by-step guides for running the code in this repository can be found in the [installation directory](https://github.com/illustrated-series/deep-learning-illustrated/tree/master/installation). 
 
 ![](https://github.com/illustrated-series/deep-learning-illustrated/blob/master/img/bespectacled_trilobite.jpeg)
 


### PR DESCRIPTION
Following the existing link in main README.md (with trilobite) and then the README.md at the destination leads to different github repository and a different set of notebooks.

Corrected the link to the local "installation" directory.